### PR TITLE
Target .NET Framework 4.8 and added the ability to optionally auto download and install 4.8 on the user's machine.

### DIFF
--- a/GenLauncherNet/App.config
+++ b/GenLauncherNet/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/GenLauncherNet/EntryPoint.cs
+++ b/GenLauncherNet/EntryPoint.cs
@@ -12,7 +12,7 @@ using System.Windows.Media.Imaging;
 
 namespace GenLauncherNet
 {
-    class EntryPoint
+    internal class EntryPoint
     {
         public const string LauncherFolder = @".GenLauncherFolder/";
         public const string ConfigName = @".GenLauncherFolder/GenLauncherCfg.yaml";
@@ -45,6 +45,10 @@ namespace GenLauncherNet
 
         private const uint RequiredNetFrameworkVersionReleaseKey = 528040; // Version 4.8
         private const string RequiredNetFrameworkVersion = "4.8"; // Release key = 528040
+
+        // Download URL for version 4.8
+        private const string RequiredNetFrameworkVersionDownloadUrl =
+            "https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/9b7b8746971ed51a1770ae4293618187/ndp48-web.exe";
 
         private static Mutex _mutex1;
 
@@ -79,7 +83,7 @@ namespace GenLauncherNet
                     var result =
                         MessageBox.Show(
                             $".NET Framework {RequiredNetFrameworkVersion} or later is required for GenLauncher. " +
-                            "Would you like to download a compatible version?",
+                            "Would you like to download and install a compatible version?",
                             $".NET Framework {RequiredNetFrameworkVersion} or later required",
                             MessageBoxButton.YesNo,
                             MessageBoxImage.Warning
@@ -87,11 +91,18 @@ namespace GenLauncherNet
 
                     if (result == MessageBoxResult.Yes)
                     {
-                        GeneralUtilities.OpenWebpageInBrowser(
-                            "https://dotnet.microsoft.com/en-us/download/dotnet-framework/thank-you/net48-web-installer");
+                        GeneralUtilities.DownloadAndInstallNetFrameworkRuntime(RequiredNetFrameworkVersionDownloadUrl);
                     }
 
-                    return;
+                    /* Check if the user has the required .NET Framework runtime version installed on there system
+                     * in the instance they clicked yes to download and install it when prompted.
+                     * If they still don't due to either the download/install failing
+                     * or if they click no on the prompt, then don't continue launching the application.
+                     */
+                    if (!GeneralUtilities.IsRequiredNetFrameworkVersionInstalled(RequiredNetFrameworkVersionReleaseKey))
+                    {
+                        return;
+                    }
                 }
 
                 if (!IsLauncherInGameFolder())

--- a/GenLauncherNet/EntryPoint.cs
+++ b/GenLauncherNet/EntryPoint.cs
@@ -21,7 +21,7 @@ namespace GenLauncherNet
         public const string GenLauncherModsFolderOld = "GenLauncherModifications";
         public const string LauncherImageSubFolder = "LauncherImages";
         public const string Version = "1.0.0.1 Release";
-        public const int LaunchersCountForUpdateAdverising = 25;
+        public const int LaunchersCountForUpdateAdvertising = 25;
 
         //public const string Version = "0.0.0.1 Test";
         public const string ModdedExeDownloadLink =

--- a/GenLauncherNet/EntryPoint.cs
+++ b/GenLauncherNet/EntryPoint.cs
@@ -80,17 +80,30 @@ namespace GenLauncherNet
 
                 if (!GeneralUtilities.IsRequiredNetFrameworkVersionInstalled(RequiredNetFrameworkVersionReleaseKey))
                 {
-                    var result =
+                    var setupPromptResult =
                         MessageBox.Show(
                             $".NET Framework {RequiredNetFrameworkVersion} or later is required for GenLauncher. " +
                             "Would you like to download and install a compatible version?",
-                            $".NET Framework {RequiredNetFrameworkVersion} or later required",
+                            $".NET Framework {RequiredNetFrameworkVersion} or later required.",
                             MessageBoxButton.YesNo,
                             MessageBoxImage.Warning
                         );
 
-                    if (result == MessageBoxResult.Yes)
+                    if (setupPromptResult == MessageBoxResult.Yes)
                     {
+                        var proceedPromptResult =
+                            MessageBox.Show(
+                                $".NET Framework {RequiredNetFrameworkVersion} will be downloaded from the following URL: " +
+                                $"{RequiredNetFrameworkVersionDownloadUrl}",
+                                "Proceed with download and installation?",
+                                MessageBoxButton.YesNo,
+                                MessageBoxImage.Question
+                            );
+                        if (proceedPromptResult == MessageBoxResult.No)
+                        {
+                            return;
+                        }
+
                         GeneralUtilities.DownloadAndInstallNetFrameworkRuntime(RequiredNetFrameworkVersionDownloadUrl);
                     }
 

--- a/GenLauncherNet/EntryPoint.cs
+++ b/GenLauncherNet/EntryPoint.cs
@@ -43,8 +43,8 @@ namespace GenLauncherNet
         public static ColorsInfo Colors;
         public static ColorsInfo DefaultColors;
 
-        private const uint RequiredNetFrameworkVersionReleaseKey = 393295; // Version 4.6
-        private const string RequiredNetFrameworkVersion = "4.6"; // Release key = 393295
+        private const uint RequiredNetFrameworkVersionReleaseKey = 528040; // Version 4.8
+        private const string RequiredNetFrameworkVersion = "4.8"; // Release key = 528040
 
         private static Mutex _mutex1;
 
@@ -67,7 +67,7 @@ namespace GenLauncherNet
 
         public static HashSet<string> GameFiles = new HashSet<string>();
 
-        [System.STAThreadAttribute()]
+        [STAThreadAttribute]
         public static void Main()
         {
             try
@@ -79,7 +79,7 @@ namespace GenLauncherNet
                     var result =
                         MessageBox.Show(
                             $".NET Framework {RequiredNetFrameworkVersion} or later is required for GenLauncher. " +
-                            $"Would you like to download a compatible version?",
+                            "Would you like to download a compatible version?",
                             $".NET Framework {RequiredNetFrameworkVersion} or later required",
                             MessageBoxButton.YesNo,
                             MessageBoxImage.Warning
@@ -117,7 +117,7 @@ namespace GenLauncherNet
 
                 PrepareLauncher();
 
-                var initWindow = new InitWindow()
+                var initWindow = new InitWindow
                     { WindowStartupLocation = System.Windows.WindowStartupLocation.CenterScreen };
 
                 app.Run(initWindow);
@@ -425,7 +425,9 @@ namespace GenLauncherNet
         {
             //TODO improve checking
             if (File.Exists("generals.exe") && File.Exists("BINKW32.DLL") &&
-                (File.Exists("WindowZH.big") || File.Exists("Window.big") || File.Exists("WindowZH.big" + GenLauncherReplaceSuffix) || File.Exists("Window.big" + GenLauncherReplaceSuffix)))
+                (File.Exists("WindowZH.big") || File.Exists("Window.big") ||
+                 File.Exists("WindowZH.big" + GenLauncherReplaceSuffix) ||
+                 File.Exists("Window.big" + GenLauncherReplaceSuffix)))
             {
                 return true;
             }

--- a/GenLauncherNet/GenLauncher.csproj
+++ b/GenLauncherNet/GenLauncher.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>GenLauncherNet</RootNamespace>
     <AssemblyName>GenLauncher</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/GenLauncherNet/Properties/Resources.Designer.cs
+++ b/GenLauncherNet/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace GenLauncherNet.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/GenLauncherNet/Properties/Settings.Designer.cs
+++ b/GenLauncherNet/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace GenLauncherNet.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/GenLauncherNet/Utility/GeneralUtilities.cs
+++ b/GenLauncherNet/Utility/GeneralUtilities.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.Windows;
+﻿using System.Diagnostics;
+using System.IO;
+using System.Net;
 using Microsoft.Win32;
 
 namespace GenLauncherNet.Utility
@@ -33,24 +32,28 @@ namespace GenLauncherNet.Utility
         }
 
         /// <summary>
-        ///     Opens a specific webpage in the user's default browser based on a given URL.
+        /// Downloads and silently Installs a specified .NET Framework runtime on the user's computer from a given download URL.
         /// </summary>
-        /// <param name="webpageUrl">URL of the webpage to open.</param>
-        internal static void OpenWebpageInBrowser(string webpageUrl)
+        /// <param name="downloadUrl">The download URL of the .NET Framework runtime version to download and install.</param>
+        internal static void DownloadAndInstallNetFrameworkRuntime(string downloadUrl)
         {
-            try
+            string tempFilePath = Path.ChangeExtension(Path.GetTempFileName(), ".exe");
+
+            /*
+             * Download the specified .NET Framework runtime installer and save it as a temporary file on the user's filesystem
+             * which is then run silently and deleted when the installer finishes.
+             */
+            using (var webClient = new WebClient())
             {
-                Process.Start(webpageUrl);
+                webClient.DownloadFile(downloadUrl, tempFilePath);
             }
-            catch (Win32Exception noBrowser)
-            {
-                if (noBrowser.ErrorCode == -2147467259)
-                    MessageBox.Show(noBrowser.Message);
-            }
-            catch (Exception other)
-            {
-                MessageBox.Show(other.Message);
-            }
+
+            var installerProcess = new Process();
+            installerProcess.StartInfo.FileName = tempFilePath;
+            installerProcess.StartInfo.Arguments = "/quiet /norestart";
+            installerProcess.Start();
+            installerProcess.WaitForExit();
+            File.Delete(tempFilePath);
         }
     }
 }

--- a/GenLauncherNet/Windows/MainWindow.xaml.cs
+++ b/GenLauncherNet/Windows/MainWindow.xaml.cs
@@ -85,9 +85,9 @@ namespace GenLauncherNet.Windows
         private void UpdateLaunchesCount()
         {
             if (DataHandler.GetLauncherCount() < 0)
-                DataHandler.SetLaunchesCount(EntryPoint.LaunchersCountForUpdateAdverising);
+                DataHandler.SetLaunchesCount(EntryPoint.LaunchersCountForUpdateAdvertising);
 
-            if (DataHandler.GetLauncherCount() > EntryPoint.LaunchersCountForUpdateAdverising)
+            if (DataHandler.GetLauncherCount() > EntryPoint.LaunchersCountForUpdateAdvertising)
             {
                 DataHandler.SetLaunchesCount(0);
 
@@ -597,7 +597,7 @@ namespace GenLauncherNet.Windows
 
         private void Exit()
         {
-            DataHandler.SetLaunchesCount(EntryPoint.LaunchersCountForUpdateAdverising);
+            DataHandler.SetLaunchesCount(EntryPoint.LaunchersCountForUpdateAdvertising);
             this.Close();
         }
 


### PR DESCRIPTION
* Updated the required .NET framework version for the application to 4.8 which is still supported by Microsoft and recommended. The relevant code has also been updated and if the user does not have a 4.8 or later, they will be prompted with an option to have GenLauncher directly download and silently install 4.8 on the user's machine.
* Made mild formatting improvements to the files I worked on and corrected a misspelling.

**Note:** Version 4.8 still supports windows 7 and 8 so by upgrading to 4.8 we benefit from using something more modern and supported without cutting out userbase.