### PR TITLE
Fixed the localization of the continue button on the use default options dialog,

### DIFF
--- a/GenLauncherNet/Windows/MainWindow.xaml.cs
+++ b/GenLauncherNet/Windows/MainWindow.xaml.cs
@@ -1429,7 +1429,7 @@ namespace GenLauncherNet.Windows
                 { WindowStartupLocation = System.Windows.WindowStartupLocation.CenterScreen };
                 infoWindow.Ok.Visibility = Visibility.Hidden;
 
-                infoWindow.Continue.Content = LocalizedStrings.Instance["Set default options"];
+                infoWindow.Continue.Content = LocalizedStrings.Instance["SetDefaultOptions"];
                 infoWindow.Cancel.Content = LocalizedStrings.Instance["No"];
 
                 infoWindow.WarningPolygon1.Visibility = Visibility.Visible;


### PR DESCRIPTION
![Screenshot 2024-02-20 000948](https://github.com/p0ls3r/GenLauncher/assets/159092807/d62cea14-60b8-4943-a505-f00272f7558c)

It now uses it properly localized value: SetDefaultOptions
